### PR TITLE
remove write on external device permission.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,8 +30,6 @@
     <uses-feature android:glEsVersion="0x00020000" /> 
 
     <!-- Allow writing to external storage -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />

--- a/android/app/src/main/java/org/rili/app/RiLi.java
+++ b/android/app/src/main/java/org/rili/app/RiLi.java
@@ -11,11 +11,6 @@ import android.os.*;
 
 public class RiLi extends SDLActivity { 
     protected void onCreate(Bundle savedInstanceState) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (super.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-                super.requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, 1);
-            }
-        }
         super.onCreate(savedInstanceState);
     }
     

--- a/src/ecran.cc
+++ b/src/ecran.cc
@@ -108,13 +108,6 @@ void Ecran::AfficheOptions(int NV,int NScore)
 /**************************/
 void Ecran::Efface(e_Sprite NumSp)
 {
-  int i;
-  
-  for(i=0;i<N;i++) {
-    if(B[i].NumSpr==corde) Sprites[B[i].NumSpr].EffaceCarre(B[i].x,B[i].y,B[i].fx,B[i].fy,
-							    Sprites[NumSp].Image[0]); 
-    else Sprites[B[i].NumSpr].Efface(B[i].x,B[i].y,B[i].Num,Sprites[NumSp].Image[0]);
-  }
   N=0;
 }
 


### PR DESCRIPTION
This prevents a crash at first run because the software starts a second time after accepting the permission causing a crash